### PR TITLE
Add a new variable to servers for online site URL

### DIFF
--- a/bin/deployer/regolith-recipe.php
+++ b/bin/deployer/regolith-recipe.php
@@ -256,13 +256,12 @@ task( 'tests:smoke', function() {
 	$environment = get( 'regolith_environment' );
 
 	$all_passed           = true;
-	$development_hostname = parse_url( WP_HOME, PHP_URL_HOST );
-	$production_hostname  = $environment['servers']['production']['hostname'];
+	$production_url       = $environment['servers']['production']['url'];
 	$cache_buster         = '/?s=' . time();
 
 	$urls = array(
-		str_replace( $development_hostname, $production_hostname, WP_HOME    ) . $cache_buster,
-		str_replace( $development_hostname, $production_hostname, WP_SITEURL ) . '/wp-login.php',
+		$production_url . $cache_buster,
+		$production_url . '/wordpress/wp-login.php',
 	);
 	$urls = array_merge( $urls, $environment['additional_test_urls'] );
 

--- a/config/environment-sample.php
+++ b/config/environment-sample.php
@@ -45,7 +45,8 @@ $deployer_environment = array(
 
 	'servers' => array(
 		'production' => array(
-			'hostname'    => 'regolith-production.net',
+			'hostname'    => 'regolith-production.net', // SSH hostname
+			'url'         => 'https://somesite.com', // Online URL for smoke test.
 			'origin_ip'   => '',    // If using an HTTP proxy like CloudFlare, enter your origin server IP. Otherwise, leave blank.
 			'username'    => 'regolith',
 			'deploy_path' => '/var/www/regolith-production.net',


### PR DESCRIPTION
In my experience with shared hosting the SSH hostname is normally on a fixed address.  At the moment the smoke tests run against this hostname which is not the URL of the site that needs testing.  This new variable allows users to specify the online site URL including scheme.

Also adjusted the smoke test path for wp-login.php to include /wordpress/