### PR TITLE
Avoid double gzipping in Supercache defaults

### DIFF
--- a/config/plugins/wp-super-cache.php
+++ b/config/plugins/wp-super-cache.php
@@ -66,7 +66,7 @@ if ( ! defined( 'WPCACHEHOME' ) ) {
 	define( 'WPCACHEHOME', WP_CONTENT_DIR . "/plugins/wp-super-cache/" );
 }
 
-$cache_compression   = 1;
+$cache_compression   = 0;
 $cache_enabled       = true;
 $super_cache_enabled = true;
 $cache_max_time      = 86400;


### PR DESCRIPTION
This default may be more sane, in my experience hosts are pretty good at having gzip enabled by default and the garbled output from double gzip can be confusing if you haven't seen it before.